### PR TITLE
include the SONIC config file and the model for running DeepTau with SONIC

### DIFF
--- a/DeepTauId/deepTau_2017v2p6_e6_full/config.pbtxt
+++ b/DeepTauId/deepTau_2017v2p6_e6_full/config.pbtxt
@@ -1,4 +1,4 @@
-name: "deeptau_nosplit"
+name: "deepTau_2017v2p6_e6_full"
 platform: "tensorflow_graphdef"
 max_batch_size: 1000
 input [

--- a/DeepTauId/deeptau_nosplit/config.pbtxt
+++ b/DeepTauId/deeptau_nosplit/config.pbtxt
@@ -1,0 +1,50 @@
+name: "deeptau_nosplit"
+platform: "tensorflow_graphdef"
+max_batch_size: 1000
+input [
+  {
+    name: "input_tau"
+    data_type: TYPE_FP32
+    dims: [47]
+  },
+  {
+    name: "input_inner_egamma"
+    data_type: TYPE_FP32
+    dims: [ 11, 11, 86 ]
+  },
+  {
+    name: "input_inner_muon"
+    data_type: TYPE_FP32
+    dims: [ 11, 11, 64 ]
+  },
+  {
+    name: "input_inner_hadrons"
+    data_type: TYPE_FP32
+    dims: [ 11, 11, 38 ]
+  },
+  {
+    name: "input_outer_egamma"
+    data_type: TYPE_FP32
+    dims: [ 21, 21, 86 ]
+  },
+  {
+    name: "input_outer_muon"
+    data_type: TYPE_FP32
+    dims: [ 21, 21, 64 ]
+  },
+  {
+    name: "input_outer_hadrons"
+    data_type: TYPE_FP32
+    dims: [ 21, 21, 38 ]
+  }
+]
+output [
+  {
+    name: "main_output/Softmax"
+    data_type: TYPE_FP32
+    dims: [ 4 ]
+  }
+]
+dynamic_batching {
+    preferred_batch_size: [ 16, 32 ]
+}


### PR DESCRIPTION
PR includes the model config file and the TF model itself in order to run DeepTauId inference with SONIC.

The model in the current PR should produce the same results as `deepTau_2017v2p6_e6` [here](https://github.com/cms-data/RecoTauTag-TrainingFiles/blob/master/DeepTauId/`, except the model in the non-split version in order to easily support batching different inference requests.